### PR TITLE
Adds GitHub action to generate dockerfiles

### DIFF
--- a/.github/workflows/generate-dockerfiles.yml
+++ b/.github/workflows/generate-dockerfiles.yml
@@ -1,0 +1,35 @@
+name: "Generate Dockerfiles"
+
+on:
+  workflow_dispatch: # Allows manual triggering from the Actions tab
+  schedule:
+    - cron: '0 12 * * 1'  # 8:00 AM EDT on Monday
+
+jobs:
+  generate_dockerfiles:
+    name: Generate Dockerfiles
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Update versions
+      run: ./version.sh
+
+    - name: Apply templates
+      run: ./apply-templates.sh
+
+    - name: Commit and push changes
+      run: |
+        git add .
+        if ! git diff --quiet --staged; then
+          git commit -m "Updates auto-generated Dockerfiles"
+          git push origin master
+        else
+          echo "No changes detected."
+        fi


### PR DESCRIPTION
This makes use of the `versions.sh` and `apply-templates.sh` scripts to attempt to regularly generate the dockerfiles and push up if there are any changes.

A separate action will be used to push these, and possibly one (or the same one) to run smoke tests.